### PR TITLE
rename invalid property name

### DIFF
--- a/svndumpfilter.py
+++ b/svndumpfilter.py
@@ -52,7 +52,7 @@ Optimizations / Improvements
        Example: You can now add --file to specify a file to read matched paths from.
 
   9.  Property tags are added to differentiate dump filter generated items.
-       Example: For the property header, a key, "K 23" as "svndumpfilter generated", is appended with a value, "V 4"
+       Example: For the property header, a key, "K 23" as "svndumpfilter:generated", is appended with a value, "V 4"
        as "True".
 
 
@@ -457,7 +457,7 @@ def handle_missing_directory(d_file, from_path, destination, rev_num, repo_path,
 def create_node_record(file_path, kind, body=None):
   """
   Creates a node record for directories to add in excluded items. The node record will
-  contain a header with a key of 'svndumpfilter generated' and a value of 'True'.
+  contain a header with a key of 'svndumpfilter:generated' and a value of 'True'.
   """
   node_rec = Record()
   node_rec.type = 'Node'
@@ -468,7 +468,7 @@ def create_node_record(file_path, kind, body=None):
   node_rec.order_head = header
   node_rec.head = dict(node_rec.order_head)
   # Number on KV header line displays length of KV content without newline character.
-  node_rec.order_prop = [('K 23\n', 'svndumpfilter generated\n'), ('V 4\n', 'True\n')]
+  node_rec.order_prop = [('K 23\n', 'svndumpfilter:generated\n'), ('V 4\n', 'True\n')]
   return node_rec
 
 


### PR DESCRIPTION
"svndumpfilter generated" is an invalid property name for Subversion even if it's not clear stated in the svnbook http://svnbook.red-bean.com/en/1.7/svn.advanced.props.html. There is already a bug report for this issue in svnbook: https://code.google.com/p/svnbook/issues/detail?id=157

The space makes problems in different places:
- CLI: 'svndumpfilter generated' is not a valid Subversion property name

```
svn pg 'svndumpfilter generated' .
svn: 'svndumpfilter generated' is not a valid Subversion property name
```
- mod_dav_svn: generates invalid XML

```
<C:svndumpfilter generated>True</C:svndumpfilter generated>
```
