### PR TITLE
Windows support: Read/write dumps in binary

### DIFF
--- a/svndumpfilter.py
+++ b/svndumpfilter.py
@@ -684,8 +684,8 @@ def parse_dump(input_dump, output_dump, matches, include, opt):
   check = create_matcher(include, matches, opt)
   clean_up(output_dump)
 
-  with open(input_dump) as input_file:
-    with open(output_dump, 'a+') as output_file:
+  with open(input_dump, 'rb') as input_file:
+    with open(output_dump, 'a+b') as output_file:
       write_dump_header(input_file, output_file, opt)
       try:
         while 1:


### PR DESCRIPTION
To make this script work on Windows, I had to make sure that the input dump was read in binary mode, and for consistency I also made the same change for the output dump.

The result worked fine on Windows on a large varied repository.

I did this with Python 2.7.1 ("(r271:86832, Aug 12 2014, 06:33:35) [MSC v.1600 64 bit (AMD64)] on win32") as distributed with a recent Subversion Edge from CollabNet.