### PR TITLE
Fixes #20: Untangled files have wrong Node-path encoding (under Windows)

### DIFF
--- a/svndumpfilter.py
+++ b/svndumpfilter.py
@@ -89,6 +89,18 @@ NODE_COPYFROM_REV = 'Node-copyfrom-rev'
 PROP_END = 'PROPS-END'
 SVN_MERGEINFO = 'svn:mergeinfo\n'
 
+def encode_to_fs(name):
+    """
+    Converts the utf-8 name to the file system encoding
+    """
+    return name.decode('utf-8').encode(sys.getfilesystemencoding())
+
+def decode_from_fs(filename):
+    """
+    Converts the filename from the file system encoding to utf-8
+    """
+    return filename.decode(sys.getfilesystemencoding()).encode('utf-8')
+
 def write_empty_lines(d_file, number=1):
     """
     Writes a variable number of empty lines.
@@ -415,6 +427,7 @@ def run_svnlook_command(command, rev_num, repo_path, file_path, filtering, debug
     """
     Runs svnlook to grab the contents of a repository or the contents of a file.
     """
+    file_path = encode_to_fs(file_path)
     command_list = ['svnlook']
     if filtering:  # svn tree
         command_list.extend([filtering, '-r', rev_num, command, repo_path, file_path])
@@ -465,6 +478,7 @@ def handle_missing_directory(d_file, from_path, destination, rev_num, repo_path,
     output = output.splitlines()
     files = filter(lambda a: a != ' ' and a != '', output)
     for transfer_file in files:
+        transfer_file = decode_from_fs(transfer_file)
         if transfer_file[-1] == '/':
             add_dir_to_dump(d_file, destination + '/' + transfer_file[len(from_path) + 1:])
         elif transfer_file == from_path + '/':


### PR DESCRIPTION
The patch converts the file names that are returned by `svnlook tree` to the utf-8 what is the dump file's (header) encoding.
It also converts the utf-8 `file_path` to the file system's encoding before calling `svnlook cat` so that it doesn't fail due to the utf-8 encoding.

This patch mainly addresses Windows because there the file system encoding is usually cp1252. For Linux the function usually converts from utf-8 to utf-8 (same encoding).